### PR TITLE
Add back upstream patch #2 for ZeroMQ

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -13,6 +13,7 @@ endef
 
 define $(package)_preprocess_cmds
    patch -p1 < $($(package)_patch_dir)/0001-fix-build-with-older-mingw64.patch && \
+   patch -p1 < $($(package)_patch_dir)/0002-disable-pthread_set_name_np.patch && \
    cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config
 endef
 


### PR DESCRIPTION
Added this back, and it compiled properly through the Docker image (cross-compile for Windows and Linux). Could you retest this and see if you see the same thing?